### PR TITLE
Test for Google Tag Manager, push event to dataLayer if exists

### DIFF
--- a/UmbracoGAEventTracking/Scripts/UmbracoGAEventTracking.js
+++ b/UmbracoGAEventTracking/Scripts/UmbracoGAEventTracking.js
@@ -4,10 +4,22 @@
     self.eventEndpoint = window.location.origin + "/Umbraco/GoogleAnalytics/GAEventTracking/GetEvents?eventRootId=" + nodeId;
     self.events = [];
     self.regex = regex;
+    self.dl = typeof (dataLayer) == 'undefined' ? [] : dataLayer; //test for dataLayer 
 
     // Methods
     function sendGaEvent(eventCategory, action, eventLabel) {
-        ga('send', 'event', eventCategory, action, eventLabel);
+
+        if (self.dl.length > 0) {
+            self.dl.push({
+                'event': 'GAEvent',
+                'eventCategory': eventCategory,
+                'eventAction': action,
+                'eventLabel': eventLabel
+            })
+        } else {
+            ga('send', 'event', eventCategory, action, eventLabel);    
+        }
+        
         //console.log(
         //    "Category: " + eventCategory
         //    + ", Action : " + action


### PR DESCRIPTION
This pushes the event to the Google Tag Manager Data Layer, if it exists, otherwise it uses the standard ga('send'...)

I make the assumption that the Data Layer variable is called what it is by default - i.e. dataLayer. If you wanted to support Data Layer renaming it could allow for it in the settings node you have in the backoffice.

If people choose to use GTM they will also need to set up a generic event in Tag Manager per instructions here:
https://www.simoahava.com/analytics/create-a-generic-event-tag/

Cheers,

Alan